### PR TITLE
Upgrade to Python 3.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ See the code in [datahound_mariadb](https://python.dbcombs.com/simple/datahound_
 
 ## Changelog
 
+3.0.0
+* Upgrade to Python 3.12
+* Updated entry_points syntax for 3.12
+
 2.0.2
 * Bug fix
 

--- a/datahound/factories.py
+++ b/datahound/factories.py
@@ -16,7 +16,7 @@ class ConnectionFactory(object):
 
     @staticmethod
     def _get_connector_by_name(connector_name: str):
-        connectors = importlib.metadata.entry_points()['datahound.connectors']
+        connectors = importlib.metadata.entry_points().select(group='datahound.connectors')
 
         for connector in connectors:
             if connector.name == connector_name:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def readme():
 
 setup(
     name='datahound',
-    version='2.0.2',
+    version='3.0.0',
     packages=find_packages(),
     url='https://python.dbcombs.com/simple/datahound',
     license='MIT',
@@ -22,9 +22,9 @@ setup(
         'datahound.connectors': ['datahound_sqlite=datahound.connectors:SqLite3Connector']
     },
     classifiers=[
-        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.12',
         'License :: MIT License',
         'Operating System :: OS Independent'
     ],
-	include_package_data=True
+    include_package_data=True
 )


### PR DESCRIPTION
Python 3.12 now required.  Updated entry_points syntax.

Here's what I see as I submit this pull request.
![Screen Shot 2024-01-08 at 7 08 38 PM](https://github.com/Techi-Freki/datahound/assets/15025333/d3a8fe86-198e-4eff-923c-4030e08772f8)
